### PR TITLE
Added microsoft-patch-index.yml file for JDK 17

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -1,0 +1,38 @@
+# Microsoft patches applied to the Microsoft Build of OpenJDK
+#
+# This index file is ouur explicit record of patches we are maintaining for our build of
+# the OpenJDK until they are (a) merged upstream, (b) abandoned, or (c) no longer
+# required by Microsoft's internal processes (we use Azure DevOps for our builds and
+# test, for instance).
+#
+# For each patch branch, there  will be a file in the ms-patches/ folder that has the
+# name of the branch in its file name (for example, this file follows that pattern).
+# The file is the source data for the README file we generate in the release branch, and
+# contains such information as Microsoft dev responsible for the patch, the original
+# author(s), associated JEP- or JBS- issue, and a summary of the patch's purpose.
+
+
+## Active Patches
+# Patches that we are applying to each release.
+active-patches:
+# - ms-patches/microsoft-patch-index // this patch branch is required for all releases
+  - ms-patches/reduced-allocation-merges
+  - ms-patches/sst
+
+
+## Upstreamed Patches
+# Patches that we are no longer applying to our releases, as they
+# have been upstreamed and are part of the official OpenJDK sources.
+#
+# upstreamed-patches: 
+  - ZZ_archive/ms-patches/8303607-ncrypt-leak-fix
+  - ZZ_archive/ms-patches/Backport-JDK-8305763-URIParsing
+
+
+# Patches that we are no longer applying to our releases as they have
+# been abandoned for one reason or another.
+#
+# abandoned-patches:
+  # - ZZ_archive/ms-patches/abandoned-feature-branch-name-1
+  # ...
+  # - ZZ_archive/ms-patches/abandoned-feature-branch-name-N

--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -16,7 +16,7 @@
 # Patches that we are applying to each release.
 active-patches:
 # - ms-patches/microsoft-patch-index // this patch branch is required for all releases
-  - ms-patches/reduced-allocation-merges
+  - ms-patches/reduce-allocation-merges
   - ms-patches/sst
 
 


### PR DESCRIPTION
Initial microsoft-patch-index.yml file for JDK 17, with active and inactive branches.