### PR TITLE
disable preventative collections by default

### DIFF
--- a/ms-patches/disable-preventative-collections-by-default.yml
+++ b/ms-patches/disable-preventative-collections-by-default.yml
@@ -1,0 +1,9 @@
+title: Disable Preventative Collections By Default
+- work_item: 2047935 
+- jbs_bug: none
+- author: macarte
+- owner: macarte
+- contributors:
+- details:
+  - Disable G1 preventive collections by default
+- release_note: Disable G1 preventive collections by default

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -309,7 +309,7 @@
           "disables this check.")                                           \
           range(0.0, (double)max_uintx)                                     \
                                                                             \
-  product(bool, G1UsePreventiveGC, true, DIAGNOSTIC,                        \
+  product(bool, G1UsePreventiveGC, false, DIAGNOSTIC,                       \
           "Allows collections to be triggered proactively based on the      \
            number of free regions and the expected survival rates in each   \
            section of the heap.")


### PR DESCRIPTION
set the default value for preventative collections to false, this does allow users to turn it back on of needed