### PR TITLE
Use GetTempPath2 when available

### DIFF
--- a/ms-patches/get-temp-path2.yaml
+++ b/ms-patches/get-temp-path2.yaml
@@ -1,0 +1,11 @@
+title: Get Temp Path 2
+- work_item: 2093754
+- author: macarte
+- owner: macarte
+- contributors:
+  - macarte
+- details:
+  - Use GetTempPath2W/A instead of GetTempPathW/A to get the path of the temporary directory.
+  - only available on Windows 11 and later, so load dynamically and fall back to GetTempPath
+  - if not available
+- release_note: GetTempPath2W/A is used to get the path of the temporary directory on Windows 11 and later.

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -903,6 +903,10 @@ typedef HRESULT (WINAPI *GetThreadDescriptionFnPtr)(HANDLE, PWSTR*);
 static SetThreadDescriptionFnPtr _SetThreadDescription = NULL;
 DEBUG_ONLY(static GetThreadDescriptionFnPtr _GetThreadDescription = NULL;)
 
+// For dynamic lookup of GetTempPath2 API
+typedef DWORD (WINAPI *GetTempPath2AFnPtr)(DWORD, LPSTR);
+static GetTempPath2AFnPtr _GetTempPath2A = nullptr;
+
 // forward decl.
 static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
@@ -1388,12 +1392,16 @@ int os::closedir(DIR *dirp) {
 // directory not the java application's temp directory, ala java.io.tmpdir.
 const char* os::get_temp_directory() {
   static char path_buf[MAX_PATH];
-  if (GetTempPath(MAX_PATH, path_buf) > 0) {
-    return path_buf;
-  } else {
-    path_buf[0] = '\0';
+  if (_GetTempPath2A != nullptr) {
+    if (_GetTempPath2A(MAX_PATH, path_buf) > 0) {
+      return path_buf;
+    }
+  }
+  else if (GetTempPath(MAX_PATH, path_buf) > 0) {
     return path_buf;
   }
+  path_buf[0] = '\0';
+  return path_buf;
 }
 
 // Needs to be in os specific directory because windows requires another
@@ -4474,6 +4482,14 @@ jint os::init_2(void) {
   }
   log_info(os, thread)("The SetThreadDescription API is%s available.", _SetThreadDescription == NULL ? " not" : "");
 
+  // Lookup GetTempPath2
+  if (_kernelbase != nullptr) {
+    _GetTempPath2A =
+      reinterpret_cast<GetTempPath2AFnPtr>(
+                                         GetProcAddress(_kernelbase,
+                                                        "GetTempPath2A"));
+  }
+  log_info(os, thread)("The _GetTempPath2A API is%s available.", _GetTempPath2A == nullptr ? " not" : "");
 
   return JNI_OK;
 }

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -350,6 +350,25 @@ SetupI18nProps(LCID lcid, char** language, char** script, char** country,
     return TRUE;
 }
 
+// For dynamic lookup of GetTempPath2 API
+typedef DWORD (WINAPI *GetTempPath2WFnPtr)(DWORD, LPWSTR);
+static GetTempPath2WFnPtr _GetTempPath2W = NULL;
+static BOOL _GetTempPath2WInitialized = FALSE;
+DWORD _GetTempPathW(DWORD nBufferLength, LPWSTR lpBuffer)
+{
+    if (!_GetTempPath2WInitialized) {
+        HINSTANCE _kernelbase = LoadLibrary(TEXT("kernelbase.dll"));
+        if (_kernelbase != NULL) {
+            _GetTempPath2W = (GetTempPath2WFnPtr)GetProcAddress(_kernelbase, "GetTempPath2W");
+        }
+        _GetTempPath2WInitialized = TRUE;
+    }
+    if (_GetTempPath2W != NULL) {
+        return _GetTempPath2W(nBufferLength, lpBuffer);
+    }
+    return GetTempPathW(nBufferLength, lpBuffer);
+}
+
 // GetVersionEx is deprecated; disable the warning until a replacement is found
 #pragma warning(disable : 4996)
 java_props_t *
@@ -368,7 +387,7 @@ GetJavaProperties(JNIEnv* env)
     {
         WCHAR tmpdir[MAX_PATH + 1];
         /* we might want to check that this succeed */
-        GetTempPathW(MAX_PATH + 1, tmpdir);
+        _GetTempPathW(MAX_PATH + 1, tmpdir);
         sprops.tmp_dir = _wcsdup(tmpdir);
     }
 

--- a/src/jdk.attach/windows/native/libattach/AttachProviderImpl.c
+++ b/src/jdk.attach/windows/native/libattach/AttachProviderImpl.c
@@ -32,6 +32,25 @@
 
 #include "sun_tools_attach_AttachProviderImpl.h"
 
+// For dynamic lookup of GetTempPath2 API
+typedef DWORD (WINAPI *GetTempPath2AFnPtr)(DWORD, LPSTR);
+static GetTempPath2AFnPtr _GetTempPath2A = NULL;
+static BOOL _GetTempPath2AInitialized = FALSE;
+DWORD _GetTempPathA(DWORD nBufferLength, LPSTR lpBuffer)
+{
+    if (!_GetTempPath2AInitialized) {
+        HINSTANCE _kernelbase = LoadLibrary(TEXT("kernelbase.dll"));
+        if (_kernelbase != NULL) {
+            _GetTempPath2A = (GetTempPath2AFnPtr)GetProcAddress(_kernelbase, "GetTempPath2A");
+        }
+        _GetTempPath2AInitialized = TRUE;
+    }
+    if (_GetTempPath2A != NULL) {
+        return _GetTempPath2A(nBufferLength, lpBuffer);
+    }
+    return GetTempPathA(nBufferLength, lpBuffer);
+}
+
 /*
  * Class:     sun_tools_attach_AttachProviderImpl
  * Method:    tempPath
@@ -45,13 +64,13 @@ Java_sun_tools_attach_AttachProviderImpl_tempPath(JNIEnv *env, jclass cls)
     jstring result = NULL;
 
     bufLen = sizeof(buf) / sizeof(char);
-    actualLen = GetTempPath(bufLen, buf);
+    actualLen = _GetTempPathA(bufLen, buf);
     if (actualLen > 0) {
         char* bufP = buf;
         if (actualLen > bufLen) {
             actualLen += sizeof(char);
             bufP = (char*)malloc(actualLen * sizeof(char));
-            actualLen = GetTempPath(actualLen, bufP);
+            actualLen = _GetTempPathA(actualLen, bufP);
         }
         if (actualLen > 0) {
             result = JNU_NewStringPlatform(env, bufP);

--- a/src/jdk.jpackage/windows/native/common/WinSysInfo.cpp
+++ b/src/jdk.jpackage/windows/native/common/WinSysInfo.cpp
@@ -32,14 +32,35 @@
 
 #pragma comment(lib, "Shell32")
 
+// For dynamic lookup of GetTempPath2 API
+typedef DWORD (WINAPI *GetTempPath2WFnPtr)(DWORD, LPWSTR);
+static GetTempPath2WFnPtr _GetTempPath2W = nullptr;
+static bool _GetTempPath2WInitialized = false;
+DWORD _GetTempPathW(DWORD nBufferLength, LPWSTR lpBuffer)
+{
+    if (!_GetTempPath2WInitialized) {
+        HINSTANCE _kernelbase = LoadLibrary(TEXT("kernelbase.dll"));
+        if (_kernelbase != nullptr) {
+            _GetTempPath2W = 
+                reinterpret_cast<GetTempPath2WFnPtr>(
+                    GetProcAddress(_kernelbase, "GetTempPath2W"));
+        }
+        _GetTempPath2WInitialized = true;
+    }
+    if (_GetTempPath2W != nullptr) {
+        return _GetTempPath2W(nBufferLength, lpBuffer);
+    }
+    return GetTempPathW(nBufferLength, lpBuffer);
+}
+
 namespace SysInfo {
 
 tstring getTempDir() {
     std::vector<TCHAR> buffer(MAX_PATH);
-    DWORD res = GetTempPath(static_cast<DWORD>(buffer.size()), buffer.data());
+    DWORD res = _GetTempPathW(static_cast<DWORD>(buffer.size()), buffer.data());
     if (res > buffer.size()) {
         buffer.resize(res);
-        GetTempPath(static_cast<DWORD>(buffer.size()), buffer.data());
+        _GetTempPathW(static_cast<DWORD>(buffer.size()), buffer.data());
     }
     return FileUtils::removeTrailingSlash(buffer.data());
 }


### PR DESCRIPTION
Use GetTempPath2W/A instead of GetTempPathW/A to get the path of the temporary directory.
Only available on Windows 11 and later, so load dynamically and fall back to GetTempPath if not available