### PR TITLE
Remove calls to test APIs unavailable in jdk17u

### DIFF
--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
@@ -66,7 +67,7 @@ public class TestAvailableProcessors {
         OutputAnalyzer outputAnalyzer = new OutputAnalyzer(processBuilder.start());
         outputAnalyzer.shouldHaveExitValue(0);
         outputAnalyzer.shouldContain(osVersionMessage);
-        List<String> lines = outputAnalyzer.stdoutAsLines();
+        List<String> lines = asLines(outputAnalyzer.getStdout());
 
         String osVersion = null;
         for (var line: lines) {
@@ -78,6 +79,10 @@ public class TestAvailableProcessors {
 
         System.out.println("Found OS version: " + osVersion);
         return osVersion;
+    }
+
+    private static List<String> asLines(String buffer) {
+        return Arrays.asList(buffer.split("\\R"));
     }
 
     private static boolean getSchedulesAllProcessorGroups(boolean isWindowsServer) throws IOException {
@@ -115,7 +120,7 @@ public class TestAvailableProcessors {
     private static OutputAnalyzer getAvailableProcessorsOutput(boolean productFlagEnabled) throws IOException {
         String productFlag = productFlagEnabled ? "-XX:+UseAllWindowsProcessorGroups" : "-XX:-UseAllWindowsProcessorGroups";
 
-        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             new String[] {productFlag, "GetAvailableProcessors"}
         );
 
@@ -128,7 +133,7 @@ public class TestAvailableProcessors {
 
     private static int getAvailableProcessors(OutputAnalyzer outputAnalyzer) {
         int runtimeAvailableProcs = 0;
-        List<String> output = outputAnalyzer.stdoutAsLines();
+        List<String> output = asLines(outputAnalyzer.getStdout());
 
         for (var line: output) {
             if (line.startsWith(runtimeAvailableProcessorsMessage)) {
@@ -188,7 +193,7 @@ public class TestAvailableProcessors {
         boolean isWindowsServer = false;
         var processorGroupSizes = new HashSet<Integer>();
 
-        List<String> lines = outputAnalyzer.stdoutAsLines();
+        List<String> lines = asLines(outputAnalyzer.getStdout());
 
         for (var line: lines) {
             if (line.startsWith(totalProcessorCountMessage)) {


### PR DESCRIPTION
Some of the usage of the OutputAnalyzer in the TestAvailableProcessors class depends on APIs that are not in the jdk17u OutputAnalyzer. This PR cleans up these issues that prevent the class from compiling in jdk17u.