### PR TITLE
Bug 2346913: TestReduceAllocationAndHeapDump Failed in 20250109.7

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -44,7 +44,7 @@ public class TestReduceAllocationAndHeapDump {
                 dumpDirectory.mkdir();
             }
 
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-server",
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-server",
                                                                       "-XX:CompileThresholdScaling=0.01",
                                                                       "-XX:+HeapDumpAfterFullGC",
                                                                       "-XX:HeapDumpPath=" + dumpDirectory.getAbsolutePath(),


### PR DESCRIPTION
Test fix by replacing "ProcessTools.createJavaProcessBuilder" with "ProcessTools.createLimitedTestJavaProcessBuilder" as per the upstream JDK 17 backport PR [8315097: Rename createJavaProcessBuilder by GoeLin · Pull Request #2960 · openjdk/jdk17u-dev](https://github.com/openjdk/jdk17u-dev/pull/2960)