### PR TITLE
8315097: Rename createJavaProcessBuilder

### DIFF
--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -120,7 +120,7 @@ public class TestAvailableProcessors {
     private static OutputAnalyzer getAvailableProcessorsOutput(boolean productFlagEnabled) throws IOException {
         String productFlag = productFlagEnabled ? "-XX:+UseAllWindowsProcessorGroups" : "-XX:-UseAllWindowsProcessorGroups";
 
-        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
             new String[] {productFlag, "GetAvailableProcessors"}
         );
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8315097 renamed the `createJavaProcessBuilder` method to `createLimitedTestJavaProcessBuilder` and that change was backported to jdk17u.

Fixes this compilation error: createJavaProcessBuilder(String...) has private access in ProcessTools