### PR TITLE
Remove ms-patches/8345296-aarch64-prctl from the patch index

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -22,7 +22,6 @@ active-patches:
   - ms-patches/use-all-windows-processor-groups
   - ms-patches/gettemppath2
   - ms-patches/remove_undocumentedAPI
-  - ms-patches/8345296-aarch64-prctl
   - ms-patches/large-pages
   - ms-patches/cleanup-unknown-unwind-opcodes
 
@@ -35,6 +34,7 @@ active-patches:
   - ZZ_archive/ms-patches/8303607-ncrypt-leak-fix
   - ZZ_archive/ms-patches/Backport-JDK-8305763-URIParsing
   - ZZ_archive/ms-patches/sst
+  - ZZ_archive/ms-patches/8345296-aarch64-prctl
 
 
 # Patches that we are no longer applying to our releases as they have


### PR DESCRIPTION
Cleanup ms-patches-index-file as the changes for ms-patches/8345296-aarch64-prctl have been upstreamed.

ms-patches branch: https://github.com/microsoft/openjdk-jdk17u/tree/ms-patches/8345296-aarch64-prctl
upstream commit: https://github.com/openjdk/jdk17u/commit/3f1ba564642fd432d733d27756ec1e57d0f89655