### PR TITLE
Move context_set_pc method to the win32 class

### DIFF
--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -139,6 +139,7 @@ public:
     _thread_ptr_offset = offset;
   }
   static inline int get_thread_ptr_offset() { return _thread_ptr_offset; }
+  static void context_set_pc(CONTEXT* uc, address pc);
 };
 
 /*
@@ -234,7 +235,6 @@ class PlatformMonitor : public PlatformMutex {
   int wait(jlong millis);
   void notify();
   void notify_all();
-  static void context_set_pc(CONTEXT* uc, address pc);
 };
 
 #endif // OS_WINDOWS_OS_WINDOWS_HPP


### PR DESCRIPTION
Fix bad merge. The new context_set_pc method should be in the win32 class.