### PR TITLE
Fix GetXSpace test

### DIFF
--- a/ms-patches/get-space.yml
+++ b/ms-patches/get-space.yml
@@ -1,0 +1,8 @@
+title: Fix GetXSpace.java test
+- work_item: 3015477
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Fix GetXSpace.java test

--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ import java.security.Permission;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import jdk.test.lib.Platform;
 import jdk.test.lib.Platform;
 
 import static java.lang.System.err;
@@ -418,24 +417,32 @@ public class GetXSpace {
         if (l.size() == 0)
             throw new RuntimeException("no partitions?");
 
-        for (int i = 0; i < sma.length; i++) {
-            System.setSecurityManager(sma[i]);
-            SecurityManager sm = System.getSecurityManager();
-            if (sma[i] != null && sm == null)
-                throw new RuntimeException("Test configuration error "
-                                           + " - can't set security manager");
-
-            out.format("%nSecurityManager = %s%n" ,
-                       (sm == null ? "null" : sm.getClass().getName()));
-            for (var p : l) {
+        for (var p : l) {
+            try {
                 Space s = new Space(p);
-                if (sm instanceof Deny) {
-                    tryCatch(s);
-                } else {
-                    compare(s);
-                    compareZeroNonExist();
-                    compareZeroExist();
+                for (int i = 0; i < sma.length; i++) {
+                    System.setSecurityManager(sma[i]);
+                    SecurityManager sm = System.getSecurityManager();
+                    if (sma[i] != null && sm == null)
+                        throw new RuntimeException("Test configuration error "
+                                                + " - can't set security manager");
+
+                    out.format("%nSecurityManager = %s%n" ,
+                           (sm == null ? "null" : sm.getClass().getName()));
+                    if (sm instanceof Deny) {
+                        tryCatch(s);
+                    } else {
+                        compare(s);
+                        compareZeroNonExist();
+                        compareZeroExist();
+                    }
                 }
+            } catch (RuntimeException x) {
+                if (Platform.isWindows() && !new File(p).exists()) {
+                    System.err.format("Skipping unavailable root %s: %s%n", p, x.getMessage());
+                    continue;
+                }
+                throw x;
             }
         }
 

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ extern "C" {
 
 #ifdef WINDOWS
 jboolean initialized = JNI_FALSE;
-BOOL(WINAPI * pfnGetDiskSpaceInformation)(LPCWSTR, LPVOID) = NULL;
+HRESULT(WINAPI * pfnGetDiskSpaceInformation)(LPCWSTR, LPVOID) = NULL;
 #endif
 
 //
@@ -82,29 +82,31 @@ Java_GetXSpace_getSpace0
     if (pfnGetDiskSpaceInformation != NULL) {
         // use GetDiskSpaceInformationW
         DISK_SPACE_INFORMATION diskSpaceInfo;
-        BOOL hres = pfnGetDiskSpaceInformation(path, &diskSpaceInfo);
-        (*env)->ReleaseStringChars(env, root, strchars);
-        if (FAILED(hres)) {
-            JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
-                                         "GetDiskSpaceInformationW");
-            return totalSpaceIsEstimated;
-        }
+        HRESULT hres = pfnGetDiskSpaceInformation(path, &diskSpaceInfo);
+        if (SUCCEEDED(hres)) {
+            (*env)->ReleaseStringChars(env, root, strchars);
 
-        ULONGLONG bytesPerAllocationUnit =
-            diskSpaceInfo.SectorsPerAllocationUnit*diskSpaceInfo.BytesPerSector;
-        array[0] = (jlong)(diskSpaceInfo.ActualTotalAllocationUnits*
-                           bytesPerAllocationUnit);
-        array[1] = (jlong)(diskSpaceInfo.CallerTotalAllocationUnits*
-                           bytesPerAllocationUnit);
-        array[2] = (jlong)(diskSpaceInfo.ActualAvailableAllocationUnits*
-                           bytesPerAllocationUnit);
-        array[3] = (jlong)(diskSpaceInfo.CallerAvailableAllocationUnits*
-                           bytesPerAllocationUnit);
+            ULONGLONG bytesPerAllocationUnit =
+                diskSpaceInfo.SectorsPerAllocationUnit*diskSpaceInfo.BytesPerSector;
+            array[0] = (jlong)(diskSpaceInfo.ActualTotalAllocationUnits*
+                               bytesPerAllocationUnit);
+            array[1] = (jlong)(diskSpaceInfo.CallerTotalAllocationUnits*
+                               bytesPerAllocationUnit);
+            array[2] = (jlong)(diskSpaceInfo.ActualAvailableAllocationUnits*
+                               bytesPerAllocationUnit);
+            array[3] = (jlong)(diskSpaceInfo.CallerAvailableAllocationUnits*
+                               bytesPerAllocationUnit);
+        } else {
+            totalSpaceIsEstimated = JNI_TRUE;
+        }
     } else {
         totalSpaceIsEstimated = JNI_TRUE;
+    }
 
-        // if GetDiskSpaceInformationW is unavailable ("The specified
-        // procedure could not be found"), fall back to GetDiskFreeSpaceExW
+    if (totalSpaceIsEstimated) {
+        // If GetDiskSpaceInformationW is unavailable or fails, fall back to
+        // GetDiskFreeSpaceExW. GetDiskSpaceInformationW can fail for some
+        // volumes, for example ReFS.
         ULARGE_INTEGER freeBytesAvailable;
         ULARGE_INTEGER totalNumberOfBytes;
         ULARGE_INTEGER totalNumberOfFreeBytes;
@@ -112,7 +114,7 @@ Java_GetXSpace_getSpace0
         BOOL hres = GetDiskFreeSpaceExW(path, &freeBytesAvailable,
             &totalNumberOfBytes, &totalNumberOfFreeBytes);
         (*env)->ReleaseStringChars(env, root, strchars);
-        if (FAILED(hres)) {
+        if (!hres) {
             JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                          "GetDiskFreeSpaceExW");
             return totalSpaceIsEstimated;


### PR DESCRIPTION
Without this patch, test/jdk/java/io/File/GetXSpace.java fails.

Backports ac4c93c17fe85fb454bd8782d2e4b2bd424de405 from https://github.com/microsoft/openjdk-jdk21u/pull/57


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
