### PR TITLE
Fix SOEDeeplyNestedBlocksTest.java test

### DIFF
--- a/ms-patches/stack-overflow-javac.yml
+++ b/ms-patches/stack-overflow-javac.yml
@@ -1,0 +1,8 @@
+title: Fix SOEDeeplyNestedBlocksTest.java test
+- work_item: 3015478
+- jbs_bug:
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Fix SOEDeeplyNestedBlocksTest.java test

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -212,4 +212,48 @@ public class SimpleJavaFileObject implements JavaFileObject {
     public String toString() {
         return getClass().getName() + "[" + toUri() + "]";
     }
+
+    /**
+     * Creates a {@link JavaFileObject} which represents the given source content.
+     *
+     * <p>The provided {@code uri} will be returned from {@link #toUri()}.
+     * The provided {@code content} will be returned from {@link #getCharContent(boolean)}.
+     * The {@link #getKind()} method will return {@link Kind#SOURCE}.
+     *
+     * <p>All other methods will behave as described in the documentation in this class,
+     * as if the constructor is called with {@code uri} and {@code Kind.SOURCE}.
+     *
+     * <p>This method can be, for example, used to compile an in-memory String
+     * to a set of classfile in a target directory:
+     * {@snippet lang="java":
+     *      var code = """
+     *                 public class CompiledCode {}
+     *                 """;
+     *      var compiler = ToolProvider.getSystemJavaCompiler();
+     *      var targetDirectory = "...";
+     *      var task = compiler.getTask(null,
+     *                                  null,
+     *                                  null,
+     *                                  List.of("-d", targetDirectory),
+     *                                  null,
+     *                                  List.of(SimpleJavaFileObject.forSource(URI.create("CompiledCode.java"), code)));
+     *      if (!task.call()) {
+     *          throw new IllegalStateException("Compilation failed!");
+     *      }
+     * }
+     *
+     * @param uri that should be used for the resulting {@code JavaFileObject}
+     * @param content the content of the {@code JavaFileObject}
+     * @return a {@code JavaFileObject} representing the given source content.
+     * @since 23
+     */
+    public static JavaFileObject forSource(URI uri, String content) {
+        return new SimpleJavaFileObject(uri, Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return content;
+            }
+        };
+    }
+
 }

--- a/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
+++ b/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8322992 8331030
+ * @summary Javac fails with StackOverflowError when compiling deeply nested synchronized blocks
+ * @run main SOEDeeplyNestedBlocksTest
+ */
+
+import java.net.*;
+import java.util.*;
+import javax.tools.*;
+
+public class SOEDeeplyNestedBlocksTest {
+
+    static final int NESTING_DEPTH = 1000;
+
+    public static void main(String... args) {
+        var lines = new ArrayList<String>();
+        lines.add("class Test {");
+        lines.add("  static { ");
+        for (int i = 0; i < NESTING_DEPTH; i++) lines.add("    synchronized (Test.class) {");
+        for (int i = 0; i < NESTING_DEPTH; i++) lines.add("    }");
+        lines.add("  }");
+        lines.add("}");
+
+        var source = SimpleJavaFileObject.forSource(URI.create("mem://Test.java"), String.join("\n", lines));
+        var compiler = ToolProvider.getSystemJavaCompiler();
+        var task = compiler.getTask(null, null, noErrors, null, null, List.of(source));
+        task.call();
+    }
+
+    static DiagnosticListener<? super JavaFileObject> noErrors = d -> {
+        System.out.println(d);
+        if (d.getKind() == Diagnostic.Kind.ERROR) {
+            throw new AssertionError(d.getMessage(null));
+        }
+    };
+}


### PR DESCRIPTION
This patch is a combination of PRs 18149 and 18939 in JDK tip.

Backports 45e5549fea15b910cc722b20dfdc8ff160946658 from https://github.com/microsoft/openjdk-jdk21u/pull/49


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
