### PR TITLE
Remove SOEDeeplyNestedBlocksTest.java patch

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -37,7 +37,6 @@ active-patches:
   - ms-patches/multiple-logins
   - ms-patches/processor-api
   - ms-patches/reserved-stack-area
-  - ms-patches/stack-overflow-javac
 
 
 ## Upstreamed Patches


### PR DESCRIPTION
This patch from https://github.com/microsoft/openjdk-jdk17u/pull/69 changes the public compiler API, which shouldn't happen in these patches

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
