### PR TITLE
Ignore "dt_socket" for Windows/ARM64

### DIFF
--- a/ms-patches/dt_socket-fix.yml
+++ b/ms-patches/dt_socket-fix.yml
@@ -1,0 +1,7 @@
+title: dt_socket
+- work_item: 3042008
+- author: raneashay
+- owner: raneashay
+- contributors: raneashay
+- details:
+- release_note: Ignore "dt_socket" for Windows/ARM64

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -604,6 +604,9 @@ class CheckedFeatures {
 
         {"windows-x64",     "com.sun.jdi.CommandLineLaunch", "dt_socket"},
         {"windows-x64",     "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
+
+        {"windows-aarch64", "com.sun.jdi.CommandLineLaunch", "dt_socket"},
+        {"windows-aarch64", "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
         {"macosx-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
         {"macosx-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},


### PR DESCRIPTION
See PR 31741 in JDK tip for details.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
